### PR TITLE
ThetaData: quieter switcher stream logging

### DIFF
--- a/dbase/DataAPI/ThetaData/switcher.py
+++ b/dbase/DataAPI/ThetaData/switcher.py
@@ -23,7 +23,7 @@ from dbase.utils import enforce_bus_hours, add_eod_timestamp
 from ..ThetaExceptions import raise_thetadata_exception
 from .patches import ThetaDataPatchProcessor
 
-logger = setup_logger("dbase.DataAPI.ThetaData.switcher", stream_log_level="INFO")
+logger = setup_logger("dbase.DataAPI.ThetaData.switcher", stream_log_level="WARNING")
 
 
 def _use_v2() -> bool:


### PR DESCRIPTION
## Summary
- Lower ThetaData switcher stream log level to WARNING to reduce INFO noise during live/dry-run runs.

## Changes
| Repo / concern | What changed |
|----------------|--------------|
| FinanceDatabase / ThetaData | `switcher.py` stream_log_level INFO → WARNING |

## Related audit
| Source | Path | Tie-in |
|--------|------|--------|
| Dry-run | `make dry-run SOURCE=live` @ 2026-07-14T22:25:06 | Stakeholder PASS; dry-run skipped for this PR create |

## Test plan
- [x] Dry-run OVERALL PASS — skipped re-run per request