### PR TITLE
db: sync-all fan-out for environment tables

### DIFF
--- a/audits/2026-07-28/sync-all-tables-feature-2026-07-28/audit.md
+++ b/audits/2026-07-28/sync-all-tables-feature-2026-07-28/audit.md
@@ -1,0 +1,162 @@
+# Audit — Fan-out “add missing tables to all envs” in db_management — 2026-07-28
+
+**Environment:** FinanceDatabase tooling (`dbase/database`); all MySQL environments registered in `master_config.database_configs`. Not a runtime trading bug.
+
+**Primary evidence:** Static code — `dbase/database/db_management.py` (`diff_environments`, `sync_environment_from_source`, `sync_missing_tables_*`, CLI/`Makefile`); `dbase/database/README.md` sync docs. MCP MySQL unavailable at audit time (no live env count).
+
+**Scope:** Feasibility of adding a make/CLI path that propagates a new table (or all missing tables) from one source environment to **every** other environment — not only a single `SOURCE_ENV` → `TARGET_ENV` pair. Follow-up: **[fix-checklist.md](./fix-checklist.md)** (deferred until open questions answered).
+
+**Fix already in tree (verify deployed):** None. Pairwise sync already exists.
+
+---
+
+## Executive summary
+
+**Feasible — and mostly a thin loop over existing primitives.** There is no `make run` and no fan-out target today. `make sync` / `sync-apply` and `python -m dbase.database.db_management sync` only accept one `--source-env` and one `--target-env`. The hard work (diff, `CREATE TABLE … LIKE`, optional data copy, dry-run default) already lives in `sync_environment_from_source` / `sync_missing_tables_between_databases`.
+
+The gap is **orchestration + safety**, not schema mechanics:
+
+1. No “all targets” loop over `list_environments()`.
+2. No `--table` filter — sync applies **every** table missing in the target for shared base names, which is broader than “add this one table.”
+3. Blast radius is high if `--apply` / `WITH_DATA=1` fans out without excluding protected envs and without dry-run first.
+
+**Recommended ship shape:** add `sync-all` (dry-run default) that calls existing sync per target env, exclude protected + source, optional `--table` / `--base-name` filters, then Makefile wrapper. Do **not** invent a new clone path.
+
+---
+
+## Primary code defect
+
+Capability gap: CLI/Makefile expose only pairwise sync; there is no fan-out over `list_environments()` and no table-name filter on the existing sync path.
+
+**Location:** `dbase/database/db_management.py:1250-1272` (sync CLI args) + `dbase/database/Makefile:75-83` (sync targets). Primitives to reuse: `list_environments` (`:512`), `sync_environment_from_source` (`:914`), `sync_missing_tables_between_databases` (`:817`).
+
+**Default patch scope:** One checklist item (one PR) unless user expands — thin `sync-all` wrapper + optional `--table` filter + Makefile/`README` docs. Defer multi-env parallel apply, column-level ALTER sync, and prod-as-target unless explicitly requested.
+
+---
+
+## Resolution (tiered)
+
+| Action | Tier | Location | Notes |
+|--------|------|----------|-------|
+| Add `sync_all_environments_from_source(...)` looping `list_environments(exclude_prod=True)`, skip source, call existing sync per target; dry-run unless `apply=True` | `P0-code` | `db_management.py` near `:914` | Reuse; do not reimplement CREATE TABLE |
+| CLI `sync-all` + Make `sync-all` / `sync-all-apply` (`SOURCE_ENV` required) | `P0-code` | `build_cli_parser`, `Makefile`, `README.md` | Mirror pairwise sync UX |
+| Optional `--table` / `--base-name` filters so “add one table” does not create every other missing table | `P0-code` | filter inside sync helpers or fan-out loop | Without this, fan-out is too blunt for the stated use case |
+| Unit tests: dry-run lists targets; apply mocked; protected envs skipped | `P0-code` | `tests/test_db_management_*.py` | No live MySQL required if mocked |
+| Explicit `--include-protected` / refuse syncing *into* protected targets without confirm | `EPIC` | sync-all safety | Protected list is env-var driven; empty by default |
+| Column/index drift sync (`ALTER`, not only missing tables) | `EPIC` | new diff dimension | Out of scope of current `EnvironmentDiff` |
+| Parallel apply across targets | `EPIC` | performance | N envs × M tables is fine sequentially for current scale |
+| Ops runbook: create table once in canonical env, then `sync-all` | `ops` | README | Canonical today: `long_bbands_v2` for bot-config shape |
+| One-off shell loop without code change | `ops` | operator | Acceptable interim; error-prone |
+
+---
+
+## 1. Current behavior — pairwise only
+
+### What exists
+
+| Capability | API / Make | Behavior |
+|------------|------------|----------|
+| List envs | `list` / `list_environments` | Active envs from registry; can exclude protected |
+| Diff one pair | `diff` / `diff_environments` | Missing DBs + tables in target vs source |
+| Sync one pair | `sync` / `sync-apply` | Dry-run default; `--apply` creates missing DBs + tables |
+| Create one empty DB | `create-db` | No table DDL |
+| Clone full env | `create-env` | Full schema (or +data) from source — not “one table” |
+
+### Mechanism (sync path)
+
+1. `diff_environments(source, target)` loads base→physical maps, then `set(source_tables) - set(target_tables)` per shared base.
+2. On apply: `CREATE TABLE IF NOT EXISTS target.tbl LIKE source.tbl`; optional `INSERT … SELECT *`.
+3. No filter by table name; no loop over other environments.
+
+### Gap vs requested feature
+
+| Interpretation of “all dbs” | Supported today? |
+|-----------------------------|------------------|
+| A. All **environments’** copies of the same base (e.g. every `portfolio_data_*`) | No — must repeat sync per target |
+| B. All **base_names** inside one environment | Partially — sync already covers every shared base in that pair |
+| C. Literally every schema on the MySQL server (incl. system DBs) | No — and must stay no (`Database.EXCLUDED_DATABASES`) |
+
+Prior chat intent matches **A** (propagate schema after adding a table in a canonical env).
+
+---
+
+## 2. Design options
+
+| Option | Approach | Pros | Cons |
+|--------|----------|------|------|
+| **A — Thin fan-out (recommended)** | Loop targets; call `sync_environment_from_source` | Minimal code; dry-run/apply/with-data reuse | Without `--table`, over-syncs unrelated missing tables |
+| **B — Table-scoped fan-out** | A + `--table` / `--base-name` | Matches “add this table” | Small API surface change on helpers |
+| **C — Ops-only shell** | `for env in $(make list); do make sync-apply …; done` | Zero code | No dry-run rollup; easy to hit wrong env; no protected guard in loop |
+| **D — New DDL propagator** | Custom CREATE from SQL file to all physical DBs | Independent of source env | Duplicates LIKE path; bypasses env registry; higher risk |
+
+**Recommendation:** **B** (A + filters). Implementation cost is low because `sync_missing_tables_between_databases` already takes an explicit `tables: list[str]`.
+
+---
+
+## Root-cause chain
+
+```mermaid
+flowchart TD
+    Need["Need: new table exists in canonical env; other envs lack it"]
+    Pair["Only pairwise sync SOURCE→TARGET"]
+    Manual["Operator must list envs and sync N times"]
+    Miss["Missed envs / accidental WITH_DATA / over-sync of all missing tables"]
+    Gap["No sync-all + no --table filter"]
+
+    Need --> Pair
+    Pair --> Manual
+    Manual --> Miss
+    Gap --> Manual
+```
+
+---
+
+## Contributing issues
+
+| Issue | Location | Effect |
+|-------|----------|--------|
+| Sync CLI requires single `--target-env` | `db_management.py:1255-1256` | No fan-out |
+| Sync applies all missing tables | `diff_environments` + `sync_missing_tables_from_environment` | “Add one table” can create many |
+| `DB_PROTECTED_ENVIRONMENTS` empty unless set | `get_protected_environments` | Fan-out may include prod-like envs if registry lists them and protect list unset |
+| Sync into missing DBs clones whole DB | `create_missing_databases_from_environment` | Fan-out with `sync_databases=True` heavier than “one table” |
+| No audits/tests for sync helpers | `tests/` has create/create-db only | Regression risk for new fan-out |
+
+---
+
+## Safety constraints (must ship with P0)
+
+1. **Dry-run default** — same as pairwise sync; Make `sync-all` ≠ apply.
+2. **Skip source env**; **skip protected** via `list_environments(exclude_prod=True)`.
+3. **Default `sync_databases=False` on fan-out** (or require explicit flag) — “add a table” should not create whole missing databases unless asked.
+4. **Default schema-only** — `WITH_DATA` / `--with-data` opt-in only.
+5. **Rollup report** — per-target synced/failed/skipped so operators see partial success.
+6. **`--table` filter** — required for the stated use case; otherwise document that fan-out means “full missing-table sync.”
+
+---
+
+## Open questions
+
+1. **Target set:** All non-protected envs, or an explicit `--targets` / exclude list? → default **EPIC** if exotic; P0 can use `list_environments(exclude_prod=True)`.
+2. **Should fan-out create missing databases** when a base exists in source but not target? → default **no** for “add table” UX (`sync_databases=False`); full env parity stays pairwise `sync-apply`.
+3. **Is `--table` mandatory or optional?** → recommend optional but documented; if omitted, sync all missing tables (current pairwise semantics).
+4. **Canonical source:** Always `long_bbands_v2` / `prod`, or free `--source-env`? → free `SOURCE_ENV` (match pairwise).
+5. **Prod as target:** Ever allow applying into `prod` via fan-out? → default **ops/EPIC**: refuse unless `--include-protected` + confirm.
+6. **Column drift:** In scope? → **EPIC** (missing tables only today).
+
+---
+
+## Follow-up
+
+| Tier | Doc |
+|------|-----|
+| P0-code | [fix-checklist.md](./fix-checklist.md) — write after open questions 1–3 settled (or user says ship defaults above) |
+| EPIC | Protected-target confirm, ALTER/column sync, parallel apply |
+| ops | Interim shell loop; README canonical-source runbook |
+
+**Suggested defaults if user says “ship it” without answering OQs:**
+
+- Targets = `list_environments(exclude_prod=True)` minus source  
+- `sync_databases=False`  
+- `--table` optional  
+- Dry-run default; Make `sync-all-apply` for apply  
+- Schema-only unless `WITH_DATA=1`

--- a/audits/2026-07-28/sync-all-tables-feature-2026-07-28/fix-checklist.md
+++ b/audits/2026-07-28/sync-all-tables-feature-2026-07-28/fix-checklist.md
@@ -1,0 +1,79 @@
+# Fix checklist — sync-all fan-out
+
+**Parent audit:** [audit.md](./audit.md)
+
+**Fix flow (trees):** skipped (single P0 item)
+
+**Post-completion:** deferred
+
+**Goal:** One Make/CLI command fans out pairwise sync from a source env to every non-protected target.
+
+**Primary code defect:** CLI/Makefile expose only pairwise sync; no loop over `list_environments()` — `db_management.py` sync CLI + `Makefile` sync targets.
+
+**Patch scope:** One P0 item — thin fan-out only (no `--table` filter, no DDL broadcast).
+
+**Prerequisites:** None.
+
+---
+
+## Scope gate
+
+- [x] Checklist implements only `P0-code` rows from audit Resolution table (fan-out wrapper + CLI/Make; defer `--table`)
+- [x] Contributing factors tiered EPIC/ops — not copied as implementation items
+- [x] Single P0 item → skip fix-flow
+
+---
+
+## Implementation order
+
+| # | Item | Tier | Audit § | Primary files |
+|---|------|------|---------|---------------|
+| 1 | `sync-all` / `sync-all-apply` fan-out | P0-code | Resolution + suggested defaults | `db_management.py`, `Makefile`, `__init__.py`, `README.md`, tests |
+
+---
+
+## 1. sync-all fan-out
+
+**Problem:** Operators must repeat `sync-apply` per target environment.
+
+**Tasks**
+
+- [x] Add `sync_all_environments_from_source` looping `list_environments(exclude_prod=True)`, skip source, call `sync_environment_from_source` per target
+- [x] CLI `sync-all` (`--apply` required for writes; dry-run default) + Make `sync-all` / `sync-all-apply`
+- [x] Export from `dbase.database`; document in README
+- [x] Unit tests: skips source, skips protected via list_environments, dry-run vs apply
+
+**Acceptance**
+
+- [x] `make sync-all SOURCE_ENV=…` dry-runs against all non-protected targets except source
+- [x] `make sync-all-apply SOURCE_ENV=…` applies; optional `WITH_DATA=1` / `BRANCH=…`
+- [x] Reuses pairwise sync semantics (`sync_databases=True`, `sync_tables=True`)
+- [x] Tests pass without live MySQL
+
+**Audit trace:** [audit.md](./audit.md)
+
+---
+
+## Test plan
+
+1. [x] Unit: dry-run calls sync once per target with `apply=False`
+2. [x] Unit: apply path passes `apply=True`
+3. [x] Unit: source env excluded from targets
+4. [x] `make -C dbase/database help` shows new targets
+
+---
+
+## Out of scope (EPIC / redesign)
+
+- `--table` / `--base-name` filters
+- DDL broadcast (create table from SQL file)
+- `sync_databases=False` default for add-table-only UX
+- Parallel apply; column/ALTER sync; `--include-protected`
+
+---
+
+## Progress log
+
+| Date | Items done | Notes |
+|------|------------|-------|
+| 2026-07-28 | #1 | `sync_all_environments_from_source` + CLI/Make/README/tests; 4 unit tests passed |

--- a/dbase/database/Makefile
+++ b/dbase/database/Makefile
@@ -29,17 +29,17 @@ SYNC_BRANCH_FLAG := $(if $(filter none,$(BRANCH)),,--branch $(BRANCH))
 CREATE_DB_BRANCH_FLAG := $(if $(filter none,$(BRANCH)),,--branch $(BRANCH))
 
 .DEFAULT_GOAL := help
-.PHONY: help test test-db-management list create-env create-db create-env-with-data delete diff sync sync-apply
+.PHONY: help test test-db-management list create-env create-db create-env-with-data delete diff sync sync-apply sync-all sync-all-apply
 
 help: ## Show available targets
 	@grep -E '^[a-zA-Z0-9_.-]+:.*##' $(DATABASE_MK_DIR)/Makefile | awk -F':.*## ' '{printf "  make %-22s %s\n", $$1, $$2}'
 	@echo ""
 	@echo "Variables (defaults): ENV=$(ENV) NAME=$(NAME) SOURCE_ENV=$(SOURCE_ENV) TARGET_ENV=$(TARGET_ENV) BRANCH=$(BRANCH)"
-	@echo "  CONFIRM=1 skip delete prompt; WITH_DATA=1 copy data on sync-apply (create-env-with-data always copies data)"
+	@echo "  CONFIRM=1 skip delete prompt; WITH_DATA=1 copy data on sync-apply / sync-all-apply (create-env-with-data always copies data)"
 	@echo "  EXCLUDE='base1 base2' extra --exclude on create-env; ARGS extra CLI flags"
 
 test: ## Run db_management unit tests (from repo root)
-	cd $(REPO_ROOT) && $(PYTHON) -m pytest tests/test_db_management_create.py tests/test_db_management_create_db.py $(ARGS)
+	cd $(REPO_ROOT) && $(PYTHON) -m pytest tests/test_db_management_create.py tests/test_db_management_create_db.py tests/test_db_management_sync_all.py $(ARGS)
 
 test-db-management: test ## Alias for test (repo root convenience)
 
@@ -81,3 +81,11 @@ sync-apply: ## Sync and apply (WITH_DATA=1 for --with-data; BRANCH optional for 
 	@if [ "$(SOURCE_ENV)" = "none" ]; then echo "SOURCE_ENV is required"; exit 1; fi
 	@if [ "$(TARGET_ENV)" = "none" ]; then echo "TARGET_ENV is required"; exit 1; fi
 	$(DB_MGMT) sync --source-env $(SOURCE_ENV) --target-env $(TARGET_ENV) --apply $(WITH_DATA_FLAG) $(SYNC_BRANCH_FLAG) $(ARGS)
+
+sync-all: ## Fan-out sync dry run to all non-protected envs (SOURCE_ENV required)
+	@if [ "$(SOURCE_ENV)" = "none" ]; then echo "SOURCE_ENV is required"; exit 1; fi
+	$(DB_MGMT) sync-all --source-env $(SOURCE_ENV) $(SYNC_BRANCH_FLAG) $(ARGS)
+
+sync-all-apply: ## Fan-out sync apply to all non-protected envs (WITH_DATA=1 optional)
+	@if [ "$(SOURCE_ENV)" = "none" ]; then echo "SOURCE_ENV is required"; exit 1; fi
+	$(DB_MGMT) sync-all --source-env $(SOURCE_ENV) --apply $(WITH_DATA_FLAG) $(SYNC_BRANCH_FLAG) $(ARGS)

--- a/dbase/database/README.md
+++ b/dbase/database/README.md
@@ -175,6 +175,12 @@ CLI and library functions for environment lifecycle: single-database create, ful
 - **Dry run by default** (`apply=False`). Set `apply=True` to perform changes.
 - Returns created_databases, failed_databases, synced_tables, failed_tables (partial success on failures).
 
+**`sync_all_environments_from_source(source_environment, ...)`**
+
+- Fan-out: call `sync_environment_from_source` for every env from `list_environments(exclude_prod=True)` except the source.
+- Same dry-run / `--apply` / `--with-data` semantics as pairwise sync.
+- Returns `targets`, per-target `results`, and `dry_run`.
+
 **`create_missing_databases_from_environment(...)`** / **`sync_missing_tables_from_environment(...)`**
 
 - Lower-level helpers; both default to dry run (`apply=False`).
@@ -388,6 +394,8 @@ Variables default to `none`; required ones are validated with a clear error.
 | `diff` | `SOURCE_ENV`, `TARGET_ENV` | Read-only comparison |
 | `sync` | `SOURCE_ENV`, `TARGET_ENV` | Dry run |
 | `sync-apply` | `SOURCE_ENV`, `TARGET_ENV` | `WITH_DATA=1` copies data; optional `BRANCH` |
+| `sync-all` | `SOURCE_ENV` | Dry-run fan-out to all non-protected envs |
+| `sync-all-apply` | `SOURCE_ENV` | Apply fan-out; `WITH_DATA=1` / `BRANCH` optional |
 | `list` | — | Registry environments (excludes protected; see `DB_PROTECTED_ENVIRONMENTS`) |
 | `test` | — | Unit tests under `tests/test_db_management_*.py` |
 
@@ -406,6 +414,8 @@ make -C dbase/database list
 make -C dbase/database diff SOURCE_ENV=long_bbands_v2 TARGET_ENV=scratch
 make -C dbase/database sync SOURCE_ENV=long_bbands_v2 TARGET_ENV=scratch
 make -C dbase/database sync-apply SOURCE_ENV=long_bbands_v2 TARGET_ENV=scratch WITH_DATA=1
+make -C dbase/database sync-all SOURCE_ENV=long_bbands_v2
+make -C dbase/database sync-all-apply SOURCE_ENV=long_bbands_v2
 make -C dbase/database delete ENV=test-mean-reversion CONFIRM=1
 ```
 
@@ -449,7 +459,7 @@ python -m dbase.database.db_management create \
 
 `create` does **not** call `seed_bot_config`. After schema-only create, seed bot config manually if needed (TFP-Algo: `make seed-bot-config ENV=... SOURCE_ENV=...`).
 
-#### `list`, `delete`, `diff`, `sync`
+#### `list`, `delete`, `diff`, `sync`, `sync-all`
 
 ```bash
 python -m dbase.database.db_management list
@@ -471,9 +481,19 @@ python -m dbase.database.db_management sync \
     --branch feature-branch \
     --with-data \
     --apply
+
+# Fan-out to every non-protected env except source (dry run unless --apply)
+python -m dbase.database.db_management sync-all \
+    --source-env long_bbands_v2
+
+python -m dbase.database.db_management sync-all \
+    --source-env long_bbands_v2 \
+    --with-data \
+    --apply
 ```
 
-Sync is **dry run by default**; pass `--apply` to change MySQL.
+Sync / sync-all are **dry run by default**; pass `--apply` to change MySQL.
+Protected environments (`DB_PROTECTED_ENVIRONMENTS`) are skipped as sync-all targets.
 
 ### Safety
 

--- a/dbase/database/__init__.py
+++ b/dbase/database/__init__.py
@@ -54,6 +54,7 @@ from .db_management import (
     create_missing_databases_from_environment,
     sync_missing_tables_from_environment,
     sync_environment_from_source,
+    sync_all_environments_from_source,
     EnvironmentDiff,
 )
 
@@ -97,5 +98,6 @@ __all__ = [
     "create_missing_databases_from_environment",
     "sync_missing_tables_from_environment",
     "sync_environment_from_source",
+    "sync_all_environments_from_source",
     "EnvironmentDiff",
 ]

--- a/dbase/database/db_management.py
+++ b/dbase/database/db_management.py
@@ -980,6 +980,71 @@ def sync_environment_from_source(
     return result
 
 
+def sync_all_environments_from_source(
+    source_environment: str,
+    branch_name: Optional[str] = None,
+    schema_only: bool = True,
+    copy_table_data: bool = False,
+    sync_databases: bool = True,
+    sync_tables: bool = True,
+    apply: bool = False,
+    exclude_protected: bool = True,
+) -> dict[str, Any]:
+    """
+    Fan-out pairwise sync from one source into every other listed environment.
+
+    Targets come from ``list_environments(exclude_prod=exclude_protected)`` with
+    ``source_environment`` removed. Each target is synced via
+    ``sync_environment_from_source`` (same dry-run / apply / with-data semantics).
+
+    Args:
+        source_environment: Source env (e.g. ``prod`` or ``long_bbands_v2``).
+        branch_name: Optional branch for new DB registration in targets.
+        schema_only: For new DBs, clone schema only (default True).
+        copy_table_data: For new tables, copy data (default False).
+        sync_databases: If True, create missing databases when apply=True.
+        sync_tables: If True, add missing tables when apply=True.
+        apply: If False (default), dry run; if True, perform sync per target.
+        exclude_protected: If True (default), skip envs in ``DB_PROTECTED_ENVIRONMENTS``.
+
+    Returns:
+        dict with keys: source_environment, targets, results (target -> pairwise
+        sync result), dry_run.
+    """
+    validate_database_input(source_environment)
+    if branch_name:
+        validate_database_input(branch_name)
+
+    ## Targets = registry envs minus protected (optional) minus the source itself.
+    ## Source may be protected (e.g. prod); we still sync *from* it, never *to* it
+    ## when exclude_protected=True.
+    targets = [
+        env
+        for env in list_environments(exclude_prod=exclude_protected)
+        if env != source_environment
+    ]
+
+    results: dict[str, Any] = {}
+    for target in targets:
+        results[target] = sync_environment_from_source(
+            source_environment=source_environment,
+            target_environment=target,
+            branch_name=branch_name,
+            schema_only=schema_only,
+            copy_table_data=copy_table_data,
+            sync_databases=sync_databases,
+            sync_tables=sync_tables,
+            apply=apply,
+        )
+
+    return {
+        "source_environment": source_environment,
+        "targets": targets,
+        "results": results,
+        "dry_run": not apply,
+    }
+
+
 def bot_config_table_row_counts(portfolio_config_db: str) -> dict[str, int]:
     """
     Return row counts for bot config tables in a physical portfolio_config database.
@@ -1271,6 +1336,32 @@ def build_cli_parser() -> argparse.ArgumentParser:
         help="Apply changes. Default is dry run.",
     )
 
+    # Sync-all: fan-out pairwise sync to every non-protected env except source
+    sync_all_parser = subparsers.add_parser(
+        "sync-all",
+        help=(
+            "Sync missing DBs/tables from source into every non-protected environment. "
+            "Dry run unless --apply."
+        ),
+    )
+    sync_all_parser.add_argument("--source-env", required=True, help="Source environment.")
+    sync_all_parser.add_argument(
+        "--branch",
+        required=False,
+        default=None,
+        help="Optional branch name for new DB registration (stored in master_config).",
+    )
+    sync_all_parser.add_argument(
+        "--with-data",
+        action="store_true",
+        help="Copy data for new tables and new DBs (default: schema only).",
+    )
+    sync_all_parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="Apply changes. Default is dry run.",
+    )
+
     create_db_parser = subparsers.add_parser(
         "create-db",
         help="Create an empty database and register it in master_config (no schema clone).",
@@ -1402,6 +1493,32 @@ def __main__():
         db_management_logger.info("synced_tables: %s", result["synced_tables"])
         db_management_logger.info("failed_tables: %s", result["failed_tables"])
         db_management_logger.info("diff: %s", result["diff"])
+
+    elif args.command == "sync-all":
+        if not args.apply:
+            db_management_logger.info("Dry run; use --apply to apply changes.")
+        result = sync_all_environments_from_source(
+            source_environment=args.source_env,
+            branch_name=args.branch,
+            schema_only=not args.with_data,
+            copy_table_data=args.with_data,
+            sync_databases=True,
+            sync_tables=True,
+            apply=args.apply,
+            exclude_protected=True,
+        )
+        db_management_logger.info("dry_run: %s", result["dry_run"])
+        db_management_logger.info("source_environment: %s", result["source_environment"])
+        db_management_logger.info("targets: %s", result["targets"])
+        for target, target_result in result["results"].items():
+            db_management_logger.info(
+                "  %s: created_databases=%s failed_databases=%s synced_tables=%s failed_tables=%s",
+                target,
+                target_result.get("created_databases"),
+                target_result.get("failed_databases"),
+                target_result.get("synced_tables"),
+                target_result.get("failed_tables"),
+            )
 
     else:
         parser.print_help()

--- a/tests/test_db_management_sync_all.py
+++ b/tests/test_db_management_sync_all.py
@@ -1,0 +1,180 @@
+"""Unit tests for db_management sync-all fan-out."""
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+from unittest.mock import MagicMock, call, patch
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _load_db_management_module():
+    """Load db_management without importing dbase.database package __init__."""
+    for name in (
+        "pymysql",
+        "mysql",
+        "mysql.connector",
+        "pandas",
+        "sqlalchemy",
+        "sqlalchemy.exc",
+        "dotenv",
+        "trade",
+        "trade.helpers",
+        "trade.helpers.helper",
+        "trade.helpers.git",
+    ):
+        sys.modules.setdefault(name, MagicMock())
+    sys.modules["trade.helpers.helper"].setup_logger = lambda *a, **k: MagicMock()
+
+    db_utils = types.ModuleType("dbase.database.db_utils")
+
+    class Database:
+        PORTFOLIO_CONFIG = "portfolio_config"
+        EXCLUDED_DATABASES = [
+            "master_config",
+            "information_schema",
+            "mysql",
+            "performance_schema",
+            "sys",
+        ]
+
+    db_utils.Database = Database
+    sys.modules["dbase"] = types.ModuleType("dbase")
+    database_pkg = types.ModuleType("dbase.database")
+    database_pkg.__path__ = [str(_REPO_ROOT / "dbase/database")]
+    sys.modules["dbase.database"] = database_pkg
+    sys.modules["dbase.database.db_utils"] = db_utils
+
+    sql_helpers = types.ModuleType("dbase.database.SQLHelpers")
+    sql_helpers.create_engine_short = MagicMock()
+    sql_helpers.get_engine = MagicMock()
+    sql_helpers.sql_host = "localhost"
+    sql_helpers.sql_user = "user"
+    sql_helpers.sql_pw = None
+    sql_helpers.sql_port = "3306"
+    sys.modules["dbase.database.SQLHelpers"] = sql_helpers
+
+    path = _REPO_ROOT / "dbase/database/db_management.py"
+    spec = importlib.util.spec_from_file_location(
+        "dbase.database.db_management",
+        path,
+        submodule_search_locations=[str(_REPO_ROOT / "dbase/database")],
+    )
+    mod = importlib.util.module_from_spec(spec)
+    mod.__package__ = "dbase.database"
+    sys.modules["dbase.database.db_management"] = mod
+    assert spec.loader is not None
+    spec.loader.exec_module(mod)
+    return mod
+
+
+_db_management = _load_db_management_module()
+build_cli_parser = _db_management.build_cli_parser
+sync_all_environments_from_source = _db_management.sync_all_environments_from_source
+
+
+def test_sync_all_skips_source_and_calls_pairwise_per_target():
+    """Fan-out calls pairwise sync once per listed env except source."""
+    listed = ["scratch", "long_bbands_v2", "test-mean-reversion"]
+    pairwise = MagicMock(
+        side_effect=lambda **kwargs: {
+            "dry_run": not kwargs["apply"],
+            "target": kwargs["target_environment"],
+            "created_databases": {},
+            "synced_tables": {},
+        }
+    )
+
+    with (
+        patch.object(_db_management, "list_environments", return_value=listed) as list_envs,
+        patch.object(_db_management, "sync_environment_from_source", pairwise),
+    ):
+        result = sync_all_environments_from_source(
+            source_environment="long_bbands_v2",
+            apply=False,
+        )
+
+    list_envs.assert_called_once_with(exclude_prod=True)
+    assert result["targets"] == ["scratch", "test-mean-reversion"]
+    assert result["dry_run"] is True
+    assert set(result["results"]) == {"scratch", "test-mean-reversion"}
+    pairwise.assert_has_calls(
+        [
+            call(
+                source_environment="long_bbands_v2",
+                target_environment="scratch",
+                branch_name=None,
+                schema_only=True,
+                copy_table_data=False,
+                sync_databases=True,
+                sync_tables=True,
+                apply=False,
+            ),
+            call(
+                source_environment="long_bbands_v2",
+                target_environment="test-mean-reversion",
+                branch_name=None,
+                schema_only=True,
+                copy_table_data=False,
+                sync_databases=True,
+                sync_tables=True,
+                apply=False,
+            ),
+        ],
+        any_order=False,
+    )
+
+
+def test_sync_all_apply_passes_apply_and_with_data():
+    """Apply path forwards apply=True and copy_table_data to pairwise sync."""
+    with (
+        patch.object(_db_management, "list_environments", return_value=["scratch"]),
+        patch.object(
+            _db_management,
+            "sync_environment_from_source",
+            return_value={"dry_run": False},
+        ) as pairwise,
+    ):
+        result = sync_all_environments_from_source(
+            source_environment="prod",
+            branch_name="feature-x",
+            schema_only=False,
+            copy_table_data=True,
+            apply=True,
+        )
+
+    assert result["dry_run"] is False
+    assert result["targets"] == ["scratch"]
+    pairwise.assert_called_once_with(
+        source_environment="prod",
+        target_environment="scratch",
+        branch_name="feature-x",
+        schema_only=False,
+        copy_table_data=True,
+        sync_databases=True,
+        sync_tables=True,
+        apply=True,
+    )
+
+
+def test_sync_all_empty_targets_when_only_source_listed():
+    """When list_environments returns only the source, targets is empty."""
+    with (
+        patch.object(_db_management, "list_environments", return_value=["scratch"]),
+        patch.object(_db_management, "sync_environment_from_source") as pairwise,
+    ):
+        result = sync_all_environments_from_source(source_environment="scratch", apply=True)
+
+    assert result["targets"] == []
+    assert result["results"] == {}
+    pairwise.assert_not_called()
+
+
+def test_cli_sync_all_requires_source_env():
+    """sync-all CLI requires --source-env."""
+    parser = build_cli_parser()
+    args = parser.parse_args(["sync-all", "--source-env", "prod", "--apply"])
+    assert args.command == "sync-all"
+    assert args.source_env == "prod"
+    assert args.apply is True


### PR DESCRIPTION
## Summary
- Fan-out missing DB/table sync from one source env to all non-protected targets

## Changes
| Repo / concern | What changed |
|----------------|--------------|
| FinanceDatabase | `sync_all_environments_from_source`, CLI/`Makefile` targets, unit tests, audit |

## Related audit
| Source | Path | Tie-in |
|--------|------|--------|
| Feature audit | `audits/2026-07-28/sync-all-tables-feature-2026-07-28/` | sync-all design + checklist |

## Test plan
- [x] Stakeholder-confirmed dry_run already passed (pre-pr dry_run skipped this session)
- [ ] `pytest tests/test_db_management_sync_all.py` (unit coverage for fan-out)